### PR TITLE
fix: encodeURI of server requests (#234)

### DIFF
--- a/lib/lib/api.js
+++ b/lib/lib/api.js
@@ -24,10 +24,11 @@ export default class API {
       path: ''
     }
   ) {
+    const URI = encodeURI(`${params.path}${this.options.endpoints.initialData}`)
     return this.$http
-      .get(`${params.path}${this.options.endpoints.initialData}`)
+      .get(URI)
       .catch((error) => {
-        logger.warn(`cant get the initial config ${this.options.baseURL}`)
+        logger.warn(`Can't get the initial config of ${this.options.baseURL}`)
         logger.error(new Error(error))
         throw error
       })


### PR DESCRIPTION
node.js requires to encode provided urls, otherwise:
```bash
TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
```