### PR TITLE
fix: handling axios errors (#291)

### DIFF
--- a/lib/lib/api.js
+++ b/lib/lib/api.js
@@ -1,4 +1,3 @@
-import logger from '~typo3/lib/logger'
 export default class API {
   /**
    * typo3 API Constructor
@@ -25,13 +24,7 @@ export default class API {
     }
   ) {
     const URI = encodeURI(`${params.path}${this.options.endpoints.initialData}`)
-    return this.$http
-      .get(URI)
-      .catch((error) => {
-        logger.warn(`Can't get the initial config of ${this.options.baseURL}`)
-        logger.error(new Error(error))
-        throw error
-      })
+    return this.$http.get(URI)
   }
 
   /**

--- a/lib/lib/context.js
+++ b/lib/lib/context.js
@@ -35,21 +35,22 @@ async function setContext (context, response) {
  * Extend NuxtContext by TYPO3 API
  *
  * @param {Object} context - NuxtContext
- * @param {Object} response - error page response
+ * @param {Object} httpError - axios error response
  * @returns {Object} context
  */
-async function setErrorContext (context, response) {
+async function setErrorContext (context, httpError) {
   const { error } = context
   const errorContext = {
     ssr: null,
-    message: response.message,
-    statusCode: response.status
+    message: httpError.response?.message || httpError.message,
+    statusCode: httpError.response?.status || 500,
+    rawError: httpError
   }
 
-  if (response.data) {
+  if (httpError.response?.data) {
     const { layout, t3page } = await setContext(
       context,
-      response
+      httpError.response
     )
 
     errorContext.ssr = {
@@ -84,7 +85,7 @@ async function contextMiddleware (context) {
 
       setContext(context, response)
     } catch (error) {
-      setErrorContext(context, error.response)
+      setErrorContext(context, error)
     }
   }
   return context

--- a/lib/plugins/api.js
+++ b/lib/plugins/api.js
@@ -1,7 +1,9 @@
 import API from '~typo3/lib/api'
 import { getLocaleCodePath } from '~typo3/lib/i18n'
+import logger from '~typo3/lib/logger'
+
 export default function (context, options) {
-  const { store, $axios } = context
+  const { store, $axios, error } = context
   let initialDataRetried = false
 
   const api = {
@@ -18,21 +20,23 @@ export default function (context, options) {
   }
 
   // add initialData fallback for 404 pages
-  api.$http.onError((error) => {
-    if (
-      error.response.status === 404 &&
-      error.config.url &&
-      error.config.url.includes(options.api.endpoints.initialData)
-    ) {
+  api.$http.onError((httpError) => {
+    if (httpError.config?.url?.includes(options.api.endpoints.initialData)) {
       if (!initialDataRetried) {
         initialDataRetried = true
+        logger.warn(`cant get the initial config ${api.options.baseURL}`)
         return api.getInitialData({
           path: getLocaleCodePath(context)
         })
       } else {
-        throw new Error(
-          `initialData fallback not available for ${error.config.baseURL}${error.config.url}`
-        )
+        const message = `initialData fallback not available for ${httpError.config.baseURL}${httpError.config.url}`
+        logger.warn(message)
+        error({
+          ssr: null,
+          message,
+          statusCode: 500,
+          rawError: httpError
+        })
       }
     }
   })

--- a/lib/store/typo3.js
+++ b/lib/store/typo3.js
@@ -1,5 +1,6 @@
 import { _types as types } from './mutation-types'
 import { isDynamicRoute } from '~typo3/lib/route'
+import logger from '~typo3/lib/logger'
 
 export const state = {
   layout: 'default',
@@ -47,7 +48,9 @@ export const actions = {
         commit(types.SET_INITIAL_DATA, data)
         Promise.resolve(data)
       })
-      .catch(error => Promise.reject(error))
+      .catch((error) => {
+        logger.error(error)
+      })
   }
 }
 


### PR DESCRIPTION
This PR solves the problem of unexpected server errors when BE is unavailable. Support for serving error page on initial data error is also added. The logic of the initial data errors is merged with the initial data fallback because it was split into two parts. 