### PR TITLE
Fix prop name in T3CeShortcut

### DIFF
--- a/lib/components/T3CeShortcut/T3CeShortcut.vue
+++ b/lib/components/T3CeShortcut/T3CeShortcut.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <T3Renderer :shortcut="shortcut" />
+    <T3Renderer :content="shortcut" />
   </div>
 </template>
 


### PR DESCRIPTION
Prop name from `T3Render` is `content`, not `shortcut`.