### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/docs/content/3.guide/4.headers.md
+++ b/docs/content/3.guide/4.headers.md
@@ -11,7 +11,7 @@ Read More [here](https://www.jsdocs.io/package/h3#setResponseHeader)
 import { setResponseHeader, setResponseHeaders } from 'h3'
 
 export default defineNuxtPlugin(() => {
-  if (process.server) {
+  if (import.meta.server) {
     // single
     setResponseHeader(useRequestEvent(), 'my-custom-header', 'true')
     // or multiple

--- a/src/runtime/composables/useT3Page.ts
+++ b/src/runtime/composables/useT3Page.ts
@@ -73,7 +73,7 @@ export const useT3Page = async (options: {
 
   return {
     pageDataFallback,
-    pageData: process.server ? pageData : ref<T3Page | null>(pageData.value),
+    pageData: import.meta.server ? pageData : ref<T3Page | null>(pageData.value),
     getPageData,
     headData,
     backendLayout,

--- a/src/runtime/lib/apiClient.ts
+++ b/src/runtime/lib/apiClient.ts
@@ -101,7 +101,7 @@ export class T3ApiClient implements T3Api {
         if (this.fetchOptions.onResponse) {
           this.fetchOptions.onResponse(context)
         }
-        if (process.server && Array.isArray(this.siteOptions.api?.proxyHeaders) && context.response.headers) {
+        if (import.meta.server && Array.isArray(this.siteOptions.api?.proxyHeaders) && context.response.headers) {
           this.apiHeaders = this.mapResponseHeaders(context.response.headers)
         }
       }

--- a/src/runtime/middleware/i18n.ts
+++ b/src/runtime/middleware/i18n.ts
@@ -10,7 +10,7 @@ export async function t3i18nMiddleware (
   const newLocale = getLocale(to.fullPath)
 
   if (
-    !process.server &&
+    !import.meta.server &&
     !isEqual(to.fullPath, from.fullPath) &&
     currentLocale.value !== newLocale
   ) {

--- a/src/runtime/middleware/initialData.ts
+++ b/src/runtime/middleware/initialData.ts
@@ -6,7 +6,7 @@ import { useT3Options } from '../composables/useT3Options'
 import { useT3i18n } from '../composables/useT3i18n'
 
 export async function t3initialDataMiddleware (to: RouteLocationNormalized) {
-  if (process.client) {
+  if (import.meta.client) {
     return
   }
 


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)