### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ npx nuxi@latest init -t gh:TYPO3-Headless/nuxt-typo3-starter <project-name>
 
 Add `@t3headless/nuxt-typo3` dev dependency to your project:
 
-```bash [yarn]
-npx nuxi@latest module add typo3
-```
-
-```bash [npm]
+```bash
 npx nuxi@latest module add typo3
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ npx nuxi@latest init -t gh:TYPO3-Headless/nuxt-typo3-starter <project-name>
 Add `@t3headless/nuxt-typo3` dev dependency to your project:
 
 ```bash [yarn]
-yarn add --dev @t3headless/nuxt-typo3
+npx nuxi@latest module add typo3
 ```
 
 ```bash [npm]
-npm install @t3headless/nuxt-typo3 --save-dev
+npx nuxi@latest module add typo3
 ```
 
 Then, add `@t3headless/nuxt-typo3` to the [`modules`](https://nuxt.com/docs/guide/concepts/modules) section of your Nuxt configuration:

--- a/docs/content/1.introduction/0.index.md
+++ b/docs/content/1.introduction/0.index.md
@@ -34,18 +34,9 @@ Please remember to set up your API URL. [Read more here](/introduction/options).
 Check out the [Nuxt 3 documentation](https://nuxt.com/docs/guide/concepts/modules){:target="_blank"} for more information about installing and using modules.
 
 Add the `@t3headless/nuxt-typo3` dependency to your project:
-
-::code-group
-  ```bash [npm]
-  npm install @t3headless/nuxt-typo3 --save-dev
-  ```
-  ```bash [yarn]
-  yarn add @t3headless/nuxt-typo3 --dev
-  ```
-  ```bash [pnpm]
-  pnpm install @t3headless/nuxt-typo3 --dev
-  ```
-::
+```bash
+npx nuxi@latest module add typo3
+```
 
 Then, add `@t3headless/nuxt-typo3` to the [`modules`](https://nuxt.com/docs/guide/concepts/modules) section of your Nuxt configuration:
 

--- a/docs/content/2.from-scratch/0.index.md
+++ b/docs/content/2.from-scratch/0.index.md
@@ -16,15 +16,9 @@ You can create a new Nuxt project using either `npx` or `pnpm`:
 ## Install and Configure `nuxt-typo3`
 
 Once your project is created, you need to install the `nuxt-typo3` module. Navigate to your project directory and use either `yarn` or `npm` to install:
-
-::code-group
-  ```bash [yarn]
-  yarn add --dev @t3headless/nuxt-typo3
-  ```
-  ```bash [npm]
-  npm install @t3headless/nuxt-typo3 --save-dev
-  ```
-::
+```bash
+npx nuxi@latest module add typo3
+```
 
 After the module is installed, you need to configure it in your `nuxt.config.ts` file. Open the file and add the following:
 

--- a/docs/content/3.guide/10.forms.md
+++ b/docs/content/3.guide/10.forms.md
@@ -11,15 +11,15 @@ Please read [EAP configuration](../join-eap/1.configuration.md) section before.
 
 ::code-group
   ```bash [npm]
-  npx nuxi@latest module add typo3
+  npm install @t3headless/nuxt-typo3-forms
   ```
   ```bash [yarn]
   echo //git.macopedia.pl/api/v4/projects/892/packages/npm/:_authToken=${NPM_TOKEN} >> .npmrc
-  npx nuxi@latest module add typo3
+  yarn add @t3headless/nuxt-typo3-forms
   ```
   ```bash [pnpm]
   echo //git.macopedia.pl/api/v4/projects/892/packages/npm/:_authToken=${NPM_TOKEN} >> .npmrc
-  npx nuxi@latest module add typo3
+  pnpm i @t3headless/nuxt-typo3-forms
   ```
 ::
 

--- a/docs/content/3.guide/10.forms.md
+++ b/docs/content/3.guide/10.forms.md
@@ -11,15 +11,15 @@ Please read [EAP configuration](../join-eap/1.configuration.md) section before.
 
 ::code-group
   ```bash [npm]
-  npm install @t3headless/nuxt-typo3-forms
+  npx nuxi@latest module add typo3
   ```
   ```bash [yarn]
   echo //git.macopedia.pl/api/v4/projects/892/packages/npm/:_authToken=${NPM_TOKEN} >> .npmrc
-  yarn add @t3headless/nuxt-typo3-forms
+  npx nuxi@latest module add typo3
   ```
   ```bash [pnpm]
   echo //git.macopedia.pl/api/v4/projects/892/packages/npm/:_authToken=${NPM_TOKEN} >> .npmrc
-  pnpm i @t3headless/nuxt-typo3-forms
+  npx nuxi@latest module add typo3
   ```
 ::
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
