### PR TITLE
refactor(plugin): migrate from window.__NUXT__ usage for Nuxt 4 compatibility

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, addRouteMiddleware, useHydration, useRequestEvent, useRequestHeaders } from '#app'
+import { defineNuxtPlugin, addRouteMiddleware, useHydration, useRequestEvent, useRequestHeaders, useNuxtApp } from '#app'
 import { setResponseHeaders } from 'h3'
 import { useT3Options } from './composables/useT3Options'
 import { useT3i18n } from './composables/useT3i18n'
@@ -51,7 +51,9 @@ export const hydrateT3ClientHeaders = (client: T3ApiClient) => {
     },
     (headers) => {
       client.fetchOptions.headers = headers
-      window.__NUXT__!['T3:api:headers'] = null
+
+      const { payload } = useNuxtApp()
+      payload!['T3:api:headers'] = null
     }
   )
 }


### PR DESCRIPTION

See Nuxt 4 upgrade guide: https://nuxt.com/docs/4.x/getting-started/upgrade#removal-of-window__nuxt__-object

I patched the package when upgrading and the rest seems to work normal
